### PR TITLE
Fixed namespace for Closure

### DIFF
--- a/src/SluggableRouter.php
+++ b/src/SluggableRouter.php
@@ -1,5 +1,6 @@
 <?php namespace Cviebrock\EloquentSluggable;
 
+use \Closure;
 use Illuminate\Routing\Router;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 


### PR DESCRIPTION
The `model` method expected an instance of Cviebrock\EloquentSluggable\Closure instead of \Closure.
